### PR TITLE
Set ecmaVersion to 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,11 @@ module.exports = {
         "browser": true,
         "node": true,
         "amd": true,
-        "es6": true
+        "es6": false
     },
+    "parserOptions": {
+        "ecmaVersion": 5
+    },    
     "rules": {
         "no-alert": 2,
         "no-array-constructor": 2,


### PR DESCRIPTION
This PR fixes a defect where ESLint would allow ES6 keywords and syntax.

I stumbled on this defect by trying to get tests with `const` keyword in them to run in PhantomJS.

ES5 is the target version supported in `sinonjs/sinon`, and should be the default across all `sinonjs/*` projects.

Setting `ecmaVersion` to `5` will help authors notice mistakes much faster than trying to figure out why PhantomJS is crashing.

Individual projects can set their own version, if they need to override this

#### To verify defect

1. In `sinon` folder
1. `git checkout e933add8c9df41253e4be341fd6e6b5079a5c95d` (current master)
1. `npm install`
1. Add some ES6 syntax to a file, like `const hello = "world";`
1. `npm run lint`
1. Observe that ESLint does not complain about the used ES6 syntax

#### To verify solution

1. In `eslint-config-sinon` folder
1. Clone this branch (use [`git pr` from `git-extras`](https://github.com/tj/git-extras/blob/master/Commands.md#git-pr))
1. `npm link`
1. In `sinon` folder, `npm link eslint-config-sinon`
1. `npm run lint`
1. Observe that ESLint now complains about the use of ES6 syntax

#### Warning!

Merging this will cause linting of current `sinonjs/sinon` `master` branch to fail, please merge https://github.com/sinonjs/sinon/pull/1425 first