### PR TITLE
Disable no-use-before-define for functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ const variables = {
     "no-undef-init": "error",
     "no-undefined": "off",
     "no-unused-vars": ["error", {"vars": "all", "args": "after-used"}],
-    "no-use-before-define": "error",
+    "no-use-before-define": ["error", {"functions": false}]
 }
 
 // https://eslint.org/docs/rules/#nodejs-and-commonjs


### PR DESCRIPTION
Functions are hoisted, so they're safe to use before they're defined.

I have verified that this works in a branch in `@sinonjs/samsam`