### PR TITLE
Add linting of jsdoc comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,8 +289,16 @@ const prettier = {
     "prettier/prettier": "error"
 };
 
+const jsDoc = {
+    "jsdoc/require-param-description": "off",
+    "jsdoc/require-returns-description": "off"
+}
+
 module.exports = {
-    "extends": ["plugin:prettier/recommended"],
+    "extends": [
+        "plugin:jsdoc/recommended",
+        "plugin:prettier/recommended"
+    ],
     "env": {
         "browser": true,
         "node": true,
@@ -301,7 +309,10 @@ module.exports = {
         "ecmaVersion": 5,
         "ecmaFeatures": {},
     },
-    "plugins": ["prettier"],
+    "plugins": [
+        "jsdoc",
+        "prettier"
+    ],
     "rules": Object.assign(
         {},
         possibleErrors,
@@ -310,6 +321,21 @@ module.exports = {
         variables,
         stylisticIssues,
         ecmaScript6,
-        prettier
-    )
+        prettier,
+        jsDoc
+    ),
+    "settings": {
+        "jsdoc": {
+            "ignorePrivate": true
+        }
+    },
+
+    overrides: [
+        {
+          files: ["*.test.*"],
+          rules: {
+            "jsdoc/require-jsdoc": "off"
+          }
+        }
+    ]
 }


### PR DESCRIPTION
This PR adds dependency on `eslint-plugin-jsdoc` with the recommended configuration. This will allow us to lint JSDoc comments in projects and allow authors to detect and fix invalid comments.

The ultimate goal is to have all Sinon projects covered with JSDoc so people using IDEs can have a great autocomplete experience.

Maybe it'll allow some automation of the creation of the typescript files for Definitely Typed. We'll see.

#### How to verify

1. Check out this branch
1. `npm link`
1. Check out `sinonjs/sinon` somewhere
1. (sinon): `npm install eslint-plugin-jsdoc` --save-dev
1. (sinon): `npm link @sinonjs/eslint-config-sinon`
1. (sinon): Write some invalid JSDoc in a source file
1. (sinon): `npm run lint`
1. Observe that the linter warns you about the invalid JSDoc