### PR TITLE
Include .browserlistrc in included files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "files": [
     "index",
     "LICENSE",
-    "README.md"
+    "README.md",
+    ".browserslistrc"
   ],
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
See sinonjs/sinon#2366

Makes it possible to reuse the browserlistrc file in the root sinon project.