### PR TITLE
disable arrow-parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ const stylisticIssues = {
 // https://eslint.org/docs/rules/#ecmascript-6
 const ecmaScript6 = {
   "arrow-body-style": ["error", "as-needed"],
-  "arrow-parens": ["error", "as-needed"],
+  // prettier: "arrow-parens": ["error", "as-needed"],
   // prettier: "arrow-spacing": "off",
   "constructor-super": "error",
   // prettier: "generator-star-spacing": "off",


### PR DESCRIPTION
Causing issues in sinonjs/sinon#2366

In line with https://github.com/prettier/eslint-config-prettier/blob/0ea836f81ac14295fb6801c4aa74446e04dda8ad/index.js#L16-L87